### PR TITLE
fixed data issue for special channels

### DIFF
--- a/brunton_lab_to_nwb/brunton_lab_to_nwb.py
+++ b/brunton_lab_to_nwb/brunton_lab_to_nwb.py
@@ -82,13 +82,13 @@ def run_conversion(
                 description='Electrooculography for tracking saccades - right',
             )
     ):
-        if kwargs['name'].encode() in special_chans:
+        if kwargs['name'].encode() in channel_labels_dset:
             nwbfile.add_acquisition(
                 TimeSeries(
                     rate=file['f_sample'][()],
                     conversion=np.nan,
                     unit='V',
-                    data=dset[:, channel_labels_dset == kwargs['name'].encode()],
+                    data=dset[:, list(channel_labels_dset).index(kwargs['name'].encode())],
                     **kwargs
                 )
             )


### PR DESCRIPTION
@bendichter @MRScheid This should fix that reported issue on those special channels.

Two things went wrong,

1) The first draft of code would add a special electrode time series to acquisition if its name was in the set of special channel names (tautological)

and

2) this would not report any error because the data it was pulling from in the `dset` was always channel zero (since the first draft indexing tested if the entire channel labels object was equal to the name of the electrode, not finding the index of that electrode, if it existed).